### PR TITLE
[WIP] Added twig extension

### DIFF
--- a/Resources/config/service.xml
+++ b/Resources/config/service.xml
@@ -2,18 +2,23 @@
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
- 
+
     <parameters>
         <parameter key="salva_assetic_filter.jshrink.class">Salva\JshrinkBundle\Assetic\Filter\JshrinkFilter</parameter>
+        <parameter key="salva_twig_extension.jshrink.class">Salva\JshrinkBundle\Twig\Extension\JshrinkExtension</parameter>
     </parameters>
- 
+
     <services>
- 
+
         <service id="salva_assetic_filter.jshrink" class="%salva_assetic_filter.jshrink.class%">
             <argument />
             <tag name="assetic.filter" alias="jshrink"></tag>
         </service>
- 
+
+        <service id="salva_twig_extension.jshrink" class="%salva_twig_extension.jshrink.class%">
+            <tag name="twig.extension" />
+        </service>
+
     </services>
- 
+
 </container>

--- a/Twig/Extension/JshrinkExtension.php
+++ b/Twig/Extension/JshrinkExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Salva\JshrinkBundle\Twig\Extension;
+
+use Salva\JshrinkBundle\Twig\TokenParser\JshrinkTokenParser;
+use Twig_Extension;
+
+/**
+ * Jshrink
+ */
+class JshrinkExtension extends Twig_Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'jshrink_extension';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTokenParsers()
+    {
+        return array(
+            new JshrinkTokenParser(),
+        );
+    }
+}

--- a/Twig/Node/JshrinkNode.php
+++ b/Twig/Node/JshrinkNode.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Salva\JshrinkBundle\Twig\Node;
+
+use Twig_Node;
+use Twig_NodeInterface;
+use Twig_Compiler;
+
+/**
+ * Jshrink
+ */
+class JshrinkNode extends Twig_Node
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(Twig_NodeInterface $body, $lineNumber, $tag = 'jshrink')
+    {
+        parent::__construct(array('body' => $body), array(), $lineNumber, $tag);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function compile(Twig_Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write("ob_start();\n")
+            ->subcompile($this->getNode('body'))
+            ->write("echo \\JShrink\\Minifier::minify(trim(ob_get_clean()));\n");
+    }
+}

--- a/Twig/TokenParser/JshrinkTokenParser.php
+++ b/Twig/TokenParser/JshrinkTokenParser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Salva\JshrinkBundle\Twig\TokenParser;
+
+use Salva\JshrinkBundle\Twig\Node\JshrinkNode;
+use Twig_Token;
+use Twig_TokenParser;
+
+/**
+ * Jshrink
+ */
+class JshrinkTokenParser extends Twig_TokenParser
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function parse(Twig_Token $token)
+    {
+        $lineNumber = $token->getLine();
+
+        $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+        $body = $this->parser->subparse(function (Twig_Token $token) {
+            return $token->test('endjshrink');
+        }, true);
+        $this->parser->getStream()->expect(Twig_Token::BLOCK_END_TYPE);
+
+        return new JshrinkNode($body, $lineNumber, $this->getTag());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTag()
+    {
+        return 'jshrink';
+    }
+}


### PR DESCRIPTION
This PR adds support for twig. It can be used like the `{% spaceless %}` extension.

Example:

```
<script type="text/javascript">{% jshrink %}
    $(document).ready(function() {
        // ...
    });
{% endjshrink %}</script>
```

What needs to be done?
- `composer.json` needs to be adjusted
- configuration parameter to enable/disable the extension (and or assetic filter?)
