### PR TITLE
Update jshrink dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"php": ">=5.3.2",
 		"symfony/assetic-bundle": "2.*",
 		"twig/extensions": "~1",
-		"tedivm/jshrink": "0.5.*"
+		"tedivm/jshrink": "~1.0"
 	},
 	"autoload": {
 		"psr-0": { "Salva\\JshrinkBundle": "" }


### PR DESCRIPTION
JShrink has gone stable: https://github.com/tedious/JShrink/blob/v1.0.0/
The API has not changed, it's still just a `Minifier::minify($js, $options)` call.
We could use the 1.0.x version constraint.
