### PR TITLE
restored php 5.3 array syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: false
 
 php:
+- 5.3
 - 5.4
 - 5.5
 - 5.6

--- a/Assetic/Filter/JshrinkFilter.php
+++ b/Assetic/Filter/JshrinkFilter.php
@@ -18,7 +18,7 @@ class JshrinkFilter implements FilterInterface
     /**
      * @param array $options
      */
-    public function __construct(array $options = [])
+    public function __construct(array $options = array())
     {
         $this->options = $options;
     }

--- a/Cache/CachedMinifier.php
+++ b/Cache/CachedMinifier.php
@@ -33,7 +33,7 @@ class CachedMinifier implements CacheInterface
             }
 
             $hash = md5($content);
-            $file = implode(DIRECTORY_SEPARATOR, [$this->cacheDir, $hash]);
+            $file = implode(DIRECTORY_SEPARATOR, array($this->cacheDir, $hash));
             if (!file_exists($file)) {
                 file_put_contents($file, \JShrink\Minifier::minify($content, $options));
             }

--- a/DependencyInjection/SalvaJshrinkExtension.php
+++ b/DependencyInjection/SalvaJshrinkExtension.php
@@ -22,9 +22,9 @@ class SalvaJshrinkExtension extends Extension
         );
         $loader->load('services.xml');
 
-        $jshrinkConfiguration = [
+        $jshrinkConfiguration = array(
             'flaggedComments' => $config['flaggedComments'],
-        ];
+        );
 
         $container
             ->getDefinition('salva_assetic_filter.jshrink')

--- a/Tests/AppKernel.php
+++ b/Tests/AppKernel.php
@@ -9,12 +9,12 @@ class AppKernel extends Kernel
 {
     public function registerBundles()
     {
-        return [
+        return array(
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\AsseticBundle\AsseticBundle(),
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \Salva\JshrinkBundle\SalvaJshrinkBundle(),
-        ];
+        );
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)

--- a/Tests/Twig/Extension/JshrinkExtensionTest.php
+++ b/Tests/Twig/Extension/JshrinkExtensionTest.php
@@ -15,9 +15,9 @@ class JshrinkExtensionTest extends Twig_Test_IntegrationTestCase
      */
     public function getExtensions()
     {
-        return [
+        return array(
             new JshrinkExtension($this->getCacheMock()),
-        ];
+        );
     }
 
     /**

--- a/Twig/Extension/JshrinkExtension.php
+++ b/Twig/Extension/JshrinkExtension.php
@@ -39,7 +39,7 @@ class JshrinkExtension extends Twig_Extension
      * @param array          $config
      * @param bool           $enabled
      */
-    public function __construct(CacheInterface $cache, array $config = [], $enabled = true)
+    public function __construct(CacheInterface $cache, array $config = array(), $enabled = true)
     {
         $this->cache = $cache;
         $this->config = $config;
@@ -48,9 +48,9 @@ class JshrinkExtension extends Twig_Extension
 
     public function getGlobals()
     {
-        return [
+        return array(
             '_jshrink_cached_minifier' => $this->cache,
-        ];
+        );
     }
 
     /**
@@ -66,8 +66,8 @@ class JshrinkExtension extends Twig_Extension
      */
     public function getTokenParsers()
     {
-        return [
+        return array(
             new JshrinkTokenParser($this->config, $this->enabled),
-        ];
+        );
     }
 }

--- a/Twig/Node/JshrinkNode.php
+++ b/Twig/Node/JshrinkNode.php
@@ -23,7 +23,7 @@ class JshrinkNode extends Twig_Node
      */
     public function __construct(Twig_NodeInterface $body, $lineNumber, $tag = 'jshrink')
     {
-        parent::__construct(['body' => $body], [], $lineNumber, $tag);
+        parent::__construct(array('body' => $body), array(), $lineNumber, $tag);
     }
 
     /**
@@ -31,7 +31,7 @@ class JshrinkNode extends Twig_Node
      *
      * @param array $config
      */
-    public function setConfig(array $config = [])
+    public function setConfig(array $config = array())
     {
         $this->config = $config;
     }

--- a/Twig/TokenParser/JshrinkTokenParser.php
+++ b/Twig/TokenParser/JshrinkTokenParser.php
@@ -29,7 +29,7 @@ class JshrinkTokenParser extends Twig_TokenParser
      * @param array $config
      * @param bool  $enabled
      */
-    public function __construct(array $config = [], $enabled = true)
+    public function __construct(array $config = array(), $enabled = true)
     {
         $this->config = $config;
         $this->enabled = (bool) $enabled;


### PR DESCRIPTION
The only difference between the two versions was the array syntax, so I've restored the PHP 5.3 compatibility.
